### PR TITLE
docs: set white background for architecture diagrams

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,6 +3,7 @@
 ## Vista general
 
 ```mermaid
+%%{init: {'themeVariables': { 'background': '#fff'}}}%%
 flowchart LR
   %% Canales
   A1["Web/Mobile\neCommerce"]:::client
@@ -123,6 +124,7 @@ flowchart LR
 ## Procesamiento de comandos e idempotencia
 
 ```mermaid
+%%{init: {'themeVariables': { 'background': '#fff'}}}%%
 flowchart TB
   CLI["Cliente\n(Idempotency-Key)"]:::client
   CTRL["Command Controller"]:::svc
@@ -182,6 +184,7 @@ flowchart TB
 ## Proyección y consultas
 
 ```mermaid
+%%{init: {'themeVariables': { 'background': '#fff'}}}%%
 flowchart TB
   BUS["Event Bus\n(partición por skuId)"]:::bus
   CONS["Projector\nidempotente"]:::svc


### PR DESCRIPTION
## Summary
- Add white background initialization to Mermaid diagrams in architecture documentation

## Testing
- `mvn -q test` *(fails: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.25.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e947056808333b32ac37170bda803