### PR TITLE
Implement stock command API with idempotency and outbox

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/meli/application/Temp.java
+++ b/src/main/java/com/meli/application/Temp.java
@@ -1,4 +1,0 @@
-package com.meli.application;
-
-public class Temp {
-}

--- a/src/main/java/com/meli/application/usecase/AdjustStockUC.java
+++ b/src/main/java/com/meli/application/usecase/AdjustStockUC.java
@@ -1,0 +1,29 @@
+package com.meli.application.usecase;
+
+import com.meli.domain.model.*;
+import com.meli.domain.repository.StockRepository;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Adjusts on hand stock by a delta value.
+ */
+@ApplicationScoped
+public class AdjustStockUC {
+    private final StockRepository repository;
+
+    @Inject
+    public AdjustStockUC(StockRepository repository) {
+        this.repository = repository;
+    }
+
+    public Uni<StockAggregate> adjust(SkuId skuId, long delta) {
+        return repository.find(skuId)
+                .onItem().transform(stock -> {
+                    stock.adjust(delta);
+                    return stock;
+                })
+                .flatMap(repository::save);
+    }
+}

--- a/src/main/java/com/meli/application/usecase/ConfirmStockUC.java
+++ b/src/main/java/com/meli/application/usecase/ConfirmStockUC.java
@@ -1,0 +1,29 @@
+package com.meli.application.usecase;
+
+import com.meli.domain.model.*;
+import com.meli.domain.repository.StockRepository;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Confirms previously reserved stock.
+ */
+@ApplicationScoped
+public class ConfirmStockUC {
+    private final StockRepository repository;
+
+    @Inject
+    public ConfirmStockUC(StockRepository repository) {
+        this.repository = repository;
+    }
+
+    public Uni<StockAggregate> confirm(SkuId skuId, long quantity) {
+        return repository.find(skuId)
+                .onItem().transform(stock -> {
+                    stock.confirm(quantity);
+                    return stock;
+                })
+                .flatMap(repository::save);
+    }
+}

--- a/src/main/java/com/meli/application/usecase/ReleaseStockUC.java
+++ b/src/main/java/com/meli/application/usecase/ReleaseStockUC.java
@@ -1,0 +1,29 @@
+package com.meli.application.usecase;
+
+import com.meli.domain.model.*;
+import com.meli.domain.repository.StockRepository;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Releases reserved stock back to available pool.
+ */
+@ApplicationScoped
+public class ReleaseStockUC {
+    private final StockRepository repository;
+
+    @Inject
+    public ReleaseStockUC(StockRepository repository) {
+        this.repository = repository;
+    }
+
+    public Uni<StockAggregate> release(SkuId skuId, long quantity) {
+        return repository.find(skuId)
+                .onItem().transform(stock -> {
+                    stock.release(quantity);
+                    return stock;
+                })
+                .flatMap(repository::save);
+    }
+}

--- a/src/main/java/com/meli/application/usecase/ReserveStockUC.java
+++ b/src/main/java/com/meli/application/usecase/ReserveStockUC.java
@@ -1,0 +1,29 @@
+package com.meli.application.usecase;
+
+import com.meli.domain.model.*;
+import com.meli.domain.repository.StockRepository;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Reserves available stock for a SKU.
+ */
+@ApplicationScoped
+public class ReserveStockUC {
+    private final StockRepository repository;
+
+    @Inject
+    public ReserveStockUC(StockRepository repository) {
+        this.repository = repository;
+    }
+
+    public Uni<StockAggregate> reserve(SkuId skuId, long quantity) {
+        return repository.find(skuId)
+                .onItem().transform(stock -> {
+                    stock.reserve(quantity);
+                    return stock;
+                })
+                .flatMap(repository::save);
+    }
+}

--- a/src/main/java/com/meli/domain/event/StockAdjusted.java
+++ b/src/main/java/com/meli/domain/event/StockAdjusted.java
@@ -1,0 +1,8 @@
+package com.meli.domain.event;
+
+import com.meli.domain.model.SkuId;
+
+/**
+ * Event emitted when on hand stock is adjusted.
+ */
+public record StockAdjusted(SkuId skuId, long delta) {}

--- a/src/main/java/com/meli/domain/event/StockConfirmed.java
+++ b/src/main/java/com/meli/domain/event/StockConfirmed.java
@@ -1,0 +1,8 @@
+package com.meli.domain.event;
+
+import com.meli.domain.model.SkuId;
+
+/**
+ * Event emitted when reserved stock is confirmed.
+ */
+public record StockConfirmed(SkuId skuId, long quantity) {}

--- a/src/main/java/com/meli/domain/event/StockReleased.java
+++ b/src/main/java/com/meli/domain/event/StockReleased.java
@@ -1,0 +1,8 @@
+package com.meli.domain.event;
+
+import com.meli.domain.model.SkuId;
+
+/**
+ * Event emitted when reserved stock is released.
+ */
+public record StockReleased(SkuId skuId, long quantity) {}

--- a/src/main/java/com/meli/domain/event/StockReserved.java
+++ b/src/main/java/com/meli/domain/event/StockReserved.java
@@ -1,0 +1,8 @@
+package com.meli.domain.event;
+
+import com.meli.domain.model.SkuId;
+
+/**
+ * Event emitted when stock is reserved.
+ */
+public record StockReserved(SkuId skuId, long quantity) {}

--- a/src/main/java/com/meli/domain/model/SkuId.java
+++ b/src/main/java/com/meli/domain/model/SkuId.java
@@ -1,0 +1,6 @@
+package com.meli.domain.model;
+
+/**
+ * Immutable identifier for a stock keeping unit.
+ */
+public record SkuId(String value) {}

--- a/src/main/java/com/meli/domain/model/StockAggregate.java
+++ b/src/main/java/com/meli/domain/model/StockAggregate.java
@@ -1,0 +1,60 @@
+package com.meli.domain.model;
+
+import com.meli.domain.event.*;
+import java.util.Objects;
+
+/**
+ * Aggregate root managing stock quantities with strong consistency.
+ */
+public class StockAggregate {
+    private final SkuId skuId;
+    private long onHand;
+    private long reserved;
+    private long version;
+
+    public StockAggregate(SkuId skuId, long onHand, long reserved, long version) {
+        this.skuId = Objects.requireNonNull(skuId);
+        this.onHand = onHand;
+        this.reserved = reserved;
+        this.version = version;
+    }
+
+    public SkuId skuId() { return skuId; }
+    public long onHand() { return onHand; }
+    public long reserved() { return reserved; }
+    public long version() { return version; }
+    public long available() { return onHand - reserved; }
+
+    public StockReserved reserve(long quantity) {
+        if (quantity <= 0) throw new IllegalArgumentException("quantity must be > 0");
+        if (available() < quantity) throw new IllegalStateException("insufficient stock");
+        reserved += quantity;
+        return new StockReserved(skuId, quantity);
+    }
+
+    public StockConfirmed confirm(long quantity) {
+        if (quantity <= 0) throw new IllegalArgumentException("quantity must be > 0");
+        if (reserved < quantity) throw new IllegalStateException("not enough reserved");
+        reserved -= quantity;
+        onHand -= quantity;
+        return new StockConfirmed(skuId, quantity);
+    }
+
+    public StockReleased release(long quantity) {
+        if (quantity <= 0) throw new IllegalArgumentException("quantity must be > 0");
+        if (reserved < quantity) throw new IllegalStateException("not enough reserved");
+        reserved -= quantity;
+        return new StockReleased(skuId, quantity);
+    }
+
+    public StockAdjusted adjust(long delta) {
+        long newOnHand = onHand + delta;
+        if (newOnHand < reserved) {
+            throw new IllegalStateException("onHand cannot be less than reserved");
+        }
+        onHand = newOnHand;
+        return new StockAdjusted(skuId, delta);
+    }
+
+    public void incrementVersion() { this.version++; }
+}

--- a/src/main/java/com/meli/domain/repository/StockRepository.java
+++ b/src/main/java/com/meli/domain/repository/StockRepository.java
@@ -1,0 +1,12 @@
+package com.meli.domain.repository;
+
+import com.meli.domain.model.*;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Port to persist and retrieve stock aggregates.
+ */
+public interface StockRepository {
+    Uni<StockAggregate> find(SkuId skuId);
+    Uni<StockAggregate> save(StockAggregate aggregate);
+}

--- a/src/main/java/com/meli/infrastructure/config/IdempotencyInterceptor.java
+++ b/src/main/java/com/meli/infrastructure/config/IdempotencyInterceptor.java
@@ -1,0 +1,44 @@
+package com.meli.infrastructure.config;
+
+import com.meli.infrastructure.repository.IdempotencyKeyEntity;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * Interceptor that ensures POST commands are processed once per Idempotency-Key header.
+ */
+@Provider
+@PreMatching
+@Priority(Priorities.AUTHENTICATION)
+@ApplicationScoped
+public class IdempotencyInterceptor implements ContainerRequestFilter {
+
+    @Inject
+    EntityManager em;
+
+    @Override
+    @Transactional
+    public void filter(ContainerRequestContext ctx) {
+        if (!"POST".equals(ctx.getMethod())) {
+            return;
+        }
+        String key = ctx.getHeaderString("Idempotency-Key");
+        if (key == null) {
+            return;
+        }
+        if (em.find(IdempotencyKeyEntity.class, key) != null) {
+            ctx.abortWith(Response.status(Response.Status.CONFLICT).entity("Duplicate request").build());
+        } else {
+            em.persist(new IdempotencyKeyEntity(key));
+        }
+    }
+}

--- a/src/main/java/com/meli/infrastructure/repository/H2StockRepository.java
+++ b/src/main/java/com/meli/infrastructure/repository/H2StockRepository.java
@@ -1,0 +1,38 @@
+package com.meli.infrastructure.repository;
+
+import com.meli.domain.model.*;
+import com.meli.domain.repository.StockRepository;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+
+/**
+ * H2 implementation of the StockRepository using JPA and optimistic locking.
+ */
+@ApplicationScoped
+public class H2StockRepository implements StockRepository {
+
+    @Inject
+    EntityManager em;
+
+    @Override
+    public Uni<StockAggregate> find(SkuId skuId) {
+        return Uni.createFrom().item(() -> em.find(StockEntity.class, skuId.value()))
+                .onItem().ifNull().failWith(() -> new IllegalArgumentException("SKU not found"))
+                .onItem().transform(StockEntity::toAggregate);
+    }
+
+    @Override
+    @Transactional
+    public Uni<StockAggregate> save(StockAggregate aggregate) {
+        return Uni.createFrom().item(() -> {
+            StockEntity merged = em.merge(StockEntity.fromAggregate(aggregate));
+            // simplistic outbox entry
+            em.persist(new OutboxEntity("StockUpdated", aggregate.skuId().value()));
+            aggregate.incrementVersion();
+            return merged.toAggregate();
+        });
+    }
+}

--- a/src/main/java/com/meli/infrastructure/repository/IdempotencyKeyEntity.java
+++ b/src/main/java/com/meli/infrastructure/repository/IdempotencyKeyEntity.java
@@ -1,0 +1,19 @@
+package com.meli.infrastructure.repository;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * Stores processed idempotency keys to avoid duplicate command execution.
+ */
+@Entity
+@Table(name = "idempotency")
+public class IdempotencyKeyEntity {
+    @Id
+    private String id;
+    @Column(name = "created_at")
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public IdempotencyKeyEntity() {}
+    public IdempotencyKeyEntity(String id) { this.id = id; }
+}

--- a/src/main/java/com/meli/infrastructure/repository/OutboxEntity.java
+++ b/src/main/java/com/meli/infrastructure/repository/OutboxEntity.java
@@ -1,0 +1,31 @@
+package com.meli.infrastructure.repository;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * Simple outbox entity storing events for later publication.
+ */
+@Entity
+@Table(name = "outbox")
+public class OutboxEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+    @Column(name = "event_type")
+    private String eventType;
+    @Lob
+    private String payload;
+    private String status = "NEW";
+    @Column(name = "created_at")
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public OutboxEntity() {}
+    public OutboxEntity(String eventType, String payload) {
+        this.eventType = eventType;
+        this.payload = payload;
+    }
+
+    public void markSent() { this.status = "SENT"; }
+    public String status() { return status; }
+}

--- a/src/main/java/com/meli/infrastructure/repository/OutboxPublisher.java
+++ b/src/main/java/com/meli/infrastructure/repository/OutboxPublisher.java
@@ -4,8 +4,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
-import io.smallrye.faulttolerance.api.CircuitBreaker;
-import io.smallrye.faulttolerance.api.Retry;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Retry;
 import io.quarkus.scheduler.Scheduled;
 import java.util.List;
 

--- a/src/main/java/com/meli/infrastructure/repository/OutboxPublisher.java
+++ b/src/main/java/com/meli/infrastructure/repository/OutboxPublisher.java
@@ -1,0 +1,33 @@
+package com.meli.infrastructure.repository;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import io.smallrye.faulttolerance.api.CircuitBreaker;
+import io.smallrye.faulttolerance.api.Retry;
+import io.quarkus.scheduler.Scheduled;
+import java.util.List;
+
+/**
+ * Periodically publishes outbox events applying retry and circuit breaker.
+ */
+@ApplicationScoped
+public class OutboxPublisher {
+
+    @Inject
+    EntityManager em;
+
+    @Scheduled(every = "10s")
+    @Retry(maxRetries = 3)
+    @CircuitBreaker(requestVolumeThreshold = 4, failureRatio = 0.75)
+    @Transactional
+    void publish() {
+        List<OutboxEntity> events = em.createQuery("from OutboxEntity where status='NEW'", OutboxEntity.class)
+                .getResultList();
+        for (OutboxEntity e : events) {
+            // placeholder for real publication
+            e.markSent();
+        }
+    }
+}

--- a/src/main/java/com/meli/infrastructure/repository/StockEntity.java
+++ b/src/main/java/com/meli/infrastructure/repository/StockEntity.java
@@ -1,0 +1,34 @@
+package com.meli.infrastructure.repository;
+
+import com.meli.domain.model.*;
+import jakarta.persistence.*;
+
+/**
+ * JPA entity backing the StockAggregate with optimistic locking.
+ */
+@Entity
+@Table(name = "stock")
+public class StockEntity {
+    @Id
+    @Column(name = "sku_id")
+    private String skuId;
+    @Column(name = "on_hand")
+    private long onHand;
+    @Column(name = "reserved")
+    private long reserved;
+    @Version
+    private long version;
+
+    public static StockEntity fromAggregate(StockAggregate agg) {
+        StockEntity e = new StockEntity();
+        e.skuId = agg.skuId().value();
+        e.onHand = agg.onHand();
+        e.reserved = agg.reserved();
+        e.version = agg.version();
+        return e;
+    }
+
+    public StockAggregate toAggregate() {
+        return new StockAggregate(new SkuId(skuId), onHand, reserved, version);
+    }
+}

--- a/src/main/java/com/meli/infrastructure/rest/command/InventoryCommandResource.java
+++ b/src/main/java/com/meli/infrastructure/rest/command/InventoryCommandResource.java
@@ -1,0 +1,74 @@
+package com.meli.infrastructure.rest.command;
+
+import com.meli.application.usecase.*;
+import com.meli.domain.model.SkuId;
+import com.meli.domain.model.StockAggregate;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * REST adapter exposing command API for stock operations.
+ */
+@Path("/v1/inventory")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class InventoryCommandResource {
+
+    @Inject
+    ReserveStockUC reserveUC;
+    @Inject
+    ConfirmStockUC confirmUC;
+    @Inject
+    ReleaseStockUC releaseUC;
+    @Inject
+    AdjustStockUC adjustUC;
+
+    @POST
+    @Path("/reserve")
+    public Uni<Response> reserve(ReserveRequest request) {
+        return reserveUC.reserve(new SkuId(request.skuId()), request.quantity())
+                .map(this::toResponse)
+                .map(Response::ok)
+                .map(Response.ResponseBuilder::build);
+    }
+
+    @POST
+    @Path("/confirm")
+    public Uni<Response> confirm(ConfirmRequest request) {
+        return confirmUC.confirm(new SkuId(request.skuId()), request.quantity())
+                .map(this::toResponse)
+                .map(Response::ok)
+                .map(Response.ResponseBuilder::build);
+    }
+
+    @POST
+    @Path("/release")
+    public Uni<Response> release(ReleaseRequest request) {
+        return releaseUC.release(new SkuId(request.skuId()), request.quantity())
+                .map(this::toResponse)
+                .map(Response::ok)
+                .map(Response.ResponseBuilder::build);
+    }
+
+    @POST
+    @Path("/adjust")
+    public Uni<Response> adjust(AdjustRequest request) {
+        return adjustUC.adjust(new SkuId(request.skuId()), request.delta())
+                .map(this::toResponse)
+                .map(Response::ok)
+                .map(Response.ResponseBuilder::build);
+    }
+
+    private StockResponse toResponse(StockAggregate agg) {
+        return new StockResponse(agg.skuId().value(), agg.onHand(), agg.reserved());
+    }
+
+    public record ReserveRequest(String skuId, long quantity) {}
+    public record ConfirmRequest(String skuId, long quantity) {}
+    public record ReleaseRequest(String skuId, long quantity) {}
+    public record AdjustRequest(String skuId, long delta) {}
+    public record StockResponse(String skuId, long onHand, long reserved) {}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:inventory;DB_CLOSE_DELAY=-1
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+quarkus.hibernate-orm.database.generation=drop-and-create
+
+# default OpenAPI and health are auto-configured

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,6 +1,21 @@
--- This file allow to write SQL commands that will be emitted in test and dev.
--- The commands are commented as their support depends of the database
--- insert into myentity (id, field) values(1, 'field-1');
--- insert into myentity (id, field) values(2, 'field-2');
--- insert into myentity (id, field) values(3, 'field-3');
--- alter sequence myentity_seq restart with 4;
+CREATE TABLE stock (
+    sku_id VARCHAR(40) PRIMARY KEY,
+    on_hand BIGINT NOT NULL,
+    reserved BIGINT NOT NULL,
+    version BIGINT NOT NULL
+);
+
+CREATE TABLE idempotency (
+    id VARCHAR(100) PRIMARY KEY,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE outbox (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    event_type VARCHAR(100),
+    payload CLOB,
+    status VARCHAR(20),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO stock (sku_id, on_hand, reserved, version) VALUES ('SKU123', 10, 0, 0);

--- a/src/test/java/com/meli/InventoryCommandResourceIT.java
+++ b/src/test/java/com/meli/InventoryCommandResourceIT.java
@@ -1,0 +1,27 @@
+package com.meli;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Integration test for InventoryCommandResource reserve endpoint.
+ */
+@QuarkusTest
+public class InventoryCommandResourceIT {
+
+    @Test
+    void reserveEndpoint() {
+        given()
+            .contentType(ContentType.JSON)
+            .header("Idempotency-Key", "it-1")
+            .body("{\"skuId\":\"SKU123\",\"quantity\":1}")
+        .when().post("/v1/inventory/reserve")
+        .then()
+            .statusCode(200)
+            .body("reserved", equalTo(1));
+    }
+}

--- a/src/test/java/com/meli/ReserveStockUCTest.java
+++ b/src/test/java/com/meli/ReserveStockUCTest.java
@@ -1,0 +1,43 @@
+package com.meli;
+
+import com.meli.application.usecase.ReserveStockUC;
+import com.meli.domain.model.*;
+import com.meli.domain.repository.StockRepository;
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+
+/**
+ * Unit test for ReserveStockUC using Mockito.
+ */
+public class ReserveStockUCTest {
+
+    @Mock
+    StockRepository repository;
+
+    @InjectMocks
+    ReserveStockUC useCase;
+
+    @BeforeEach
+    void init() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void reservesWhenAvailable() {
+        SkuId sku = new SkuId("SKU1");
+        StockAggregate agg = new StockAggregate(sku, 10, 0, 0);
+        Mockito.when(repository.find(sku)).thenReturn(Uni.createFrom().item(agg));
+        Mockito.when(repository.save(any())).thenAnswer(inv -> Uni.createFrom().item(inv.getArgument(0)));
+
+        StockAggregate result = useCase.reserve(sku, 5).await().indefinitely();
+        assertEquals(5, result.reserved());
+    }
+}

--- a/src/test/java/com/meli/ReserveStockUCTest.java
+++ b/src/test/java/com/meli/ReserveStockUCTest.java
@@ -35,7 +35,8 @@ public class ReserveStockUCTest {
         SkuId sku = new SkuId("SKU1");
         StockAggregate agg = new StockAggregate(sku, 10, 0, 0);
         Mockito.when(repository.find(sku)).thenReturn(Uni.createFrom().item(agg));
-        Mockito.when(repository.save(any())).thenAnswer(inv -> Uni.createFrom().item(inv.getArgument(0)));
+        Mockito.when(repository.save(any())).thenAnswer(inv ->
+                Uni.createFrom().item((StockAggregate) inv.getArgument(0)));
 
         StockAggregate result = useCase.reserve(sku, 5).await().indefinitely();
         assertEquals(5, result.reserved());


### PR DESCRIPTION
## Summary
- add domain model and events for stock
- implement use cases and REST command endpoints with idempotency interceptor
- persist stock in H2 with outbox and retrying publisher

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: Plugin io.quarkus.platform:quarkus-maven-plugin:3.25.3 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689e9f0c10988333be99c7c904b2fdaf