### PR TITLE
Fix duplicate table creation and update schema generation config

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,8 @@ quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:inventory;DB_CLOSE_DELAY=-1
 quarkus.datasource.username=sa
 quarkus.datasource.password=sa
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.database.schema-generation=drop-and-create
+# load data from import.sql after schema generation
+quarkus.hibernate-orm.sql-load-script=import.sql
 
 # default OpenAPI and health are auto-configured

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,21 +1,5 @@
-CREATE TABLE stock (
-    sku_id VARCHAR(40) PRIMARY KEY,
-    on_hand BIGINT NOT NULL,
-    reserved BIGINT NOT NULL,
-    version BIGINT NOT NULL
-);
+-- Initial data for the inventory database
+-- The schema is managed by Hibernate; this script inserts seed data only
 
-CREATE TABLE idempotency (
-    id VARCHAR(100) PRIMARY KEY,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE TABLE outbox (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    event_type VARCHAR(100),
-    payload CLOB,
-    status VARCHAR(20),
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-
-INSERT INTO stock (sku_id, on_hand, reserved, version) VALUES ('SKU123', 10, 0, 0);
+INSERT INTO stock (sku_id, on_hand, reserved, version)
+VALUES ('SKU123', 10, 0, 0);


### PR DESCRIPTION
## Summary
- avoid re-creating tables by removing schema DDL from import.sql
- update to new `quarkus.hibernate-orm.database.schema-generation` property and specify data load script

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ea650766c833390b0caa99f649083