### PR TITLE
Fix Hibernate schema generation property

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:inventory;DB_CLOSE_DELAY=-1
 quarkus.datasource.username=sa
 quarkus.datasource.password=sa
-quarkus.hibernate-orm.database.schema-generation=drop-and-create
+quarkus.hibernate-orm.database.generation=drop-and-create
 # load data from import.sql after schema generation
 quarkus.hibernate-orm.sql-load-script=import.sql
 


### PR DESCRIPTION
## Summary
- correct Hibernate ORM config property to create schema in dev H2 database

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: Plugin io.quarkus.platform:quarkus-maven-plugin:3.25.3 or one of its dependencies could not be resolved: Failed to read artifact descriptor for io.quarkus.platform:quarkus-maven-plugin:jar:3.25.3)*

------
https://chatgpt.com/codex/tasks/task_e_689ea7d52ef48333b49f8e1e5cf26911