### PR TITLE
Mark idempotency filter as blocking

### DIFF
--- a/src/main/java/com/meli/infrastructure/config/IdempotencyInterceptor.java
+++ b/src/main/java/com/meli/infrastructure/config/IdempotencyInterceptor.java
@@ -1,6 +1,7 @@
 package com.meli.infrastructure.config;
 
 import com.meli.infrastructure.repository.IdempotencyKeyEntity;
+import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -21,6 +22,7 @@ public class IdempotencyInterceptor {
     EntityManager em;
 
     @ServerRequestFilter
+    @Blocking
     @Transactional
     public Uni<Void> filter(ContainerRequestContext ctx) {
         if (!"POST".equals(ctx.getMethod())) {
@@ -30,7 +32,7 @@ public class IdempotencyInterceptor {
         if (key == null) {
             return Uni.createFrom().voidItem();
         }
-        return Uni.createFrom().item(() -> {
+        return Uni.createFrom().<Void>item(() -> {
             if (em.find(IdempotencyKeyEntity.class, key) != null) {
                 ctx.abortWith(Response.status(409).entity("Duplicate request").build());
             } else {

--- a/src/main/java/com/meli/infrastructure/config/IdempotencyInterceptor.java
+++ b/src/main/java/com/meli/infrastructure/config/IdempotencyInterceptor.java
@@ -1,6 +1,7 @@
 package com.meli.infrastructure.config;
 
 import com.meli.infrastructure.repository.IdempotencyKeyEntity;
+import io.smallrye.common.annotation.Blocking;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -26,6 +27,7 @@ public class IdempotencyInterceptor implements ContainerRequestFilter {
     EntityManager em;
 
     @Override
+    @Blocking
     @Transactional
     public void filter(ContainerRequestContext ctx) {
         if (!"POST".equals(ctx.getMethod())) {

--- a/src/main/java/com/meli/infrastructure/config/IdempotencyInterceptor.java
+++ b/src/main/java/com/meli/infrastructure/config/IdempotencyInterceptor.java
@@ -22,7 +22,7 @@ public class IdempotencyInterceptor {
     @ServerRequestFilter
     @Blocking
     @Transactional
-    void filter(ContainerRequestContext ctx) {
+    public void filter(ContainerRequestContext ctx) {
         if (!"POST".equals(ctx.getMethod())) {
             return;
         }

--- a/src/main/java/com/meli/infrastructure/config/IdempotencyInterceptor.java
+++ b/src/main/java/com/meli/infrastructure/config/IdempotencyInterceptor.java
@@ -2,31 +2,25 @@ package com.meli.infrastructure.config;
 
 import com.meli.infrastructure.repository.IdempotencyKeyEntity;
 import io.smallrye.common.annotation.Blocking;
-import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
-import jakarta.ws.rs.container.ContainerRequestFilter;
-import jakarta.ws.rs.container.PreMatching;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.ext.Provider;
+import org.jboss.resteasy.reactive.server.ServerRequestFilter;
 
 /**
  * Interceptor that ensures POST commands are processed once per Idempotency-Key header.
  */
-@Provider
-@PreMatching
-@Priority(Priorities.AUTHENTICATION)
 @ApplicationScoped
-public class IdempotencyInterceptor implements ContainerRequestFilter {
+public class IdempotencyInterceptor {
 
     @Inject
     EntityManager em;
 
-    @Override
+    @ServerRequestFilter(preMatching = true, priority = Priorities.AUTHENTICATION)
     @Blocking
     @Transactional
     public void filter(ContainerRequestContext ctx) {


### PR DESCRIPTION
## Summary
- ensure idempotency filter runs on a worker thread by adding @Blocking annotation

## Testing
- ⚠️ `mvn -q test` *(failed: could not resolve dependencies, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689eaadaf8f48333b4c8b9db06dbea34