### PR TITLE
refactor: extract inventory command service

### DIFF
--- a/src/main/java/com/meli/application/service/InventoryCommandService.java
+++ b/src/main/java/com/meli/application/service/InventoryCommandService.java
@@ -1,0 +1,81 @@
+package com.meli.application.service;
+
+import com.meli.application.usecase.*;
+import com.meli.domain.model.SkuId;
+import com.meli.domain.model.StockAggregate;
+import io.quarkus.hibernate.reactive.panache.Panache;
+import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Application service coordinating inventory commands with idempotency and transactions.
+ * Encapsulates use case execution and response mapping keeping REST resource lean.
+ */
+@ApplicationScoped
+public class InventoryCommandService {
+
+    @Inject IdempotencyServiceReactive idem;
+    @Inject ReserveStockUC reserveUC;
+    @Inject ConfirmStockUC confirmUC;
+    @Inject ReleaseStockUC releaseUC;
+    @Inject AdjustStockUC  adjustUC;
+
+    @WithTransaction
+    public Uni<Response> reserve(String key, ReserveRequest req) {
+        String hash = IdempotencyServiceReactive.hash("POST", "/v1/inventory/reserve", req);
+        return Panache.getSession().flatMap(session ->
+            idem.execute(key, hash,
+                () -> reserveUC.reserve(new SkuId(req.skuId()), req.quantity())
+                               .map(this::toCreatedResponse),
+                session));
+    }
+
+    @WithTransaction
+    public Uni<Response> confirm(String key, ConfirmRequest req) {
+        String hash = IdempotencyServiceReactive.hash("POST", "/v1/inventory/confirm", req);
+        return Panache.getSession().flatMap(session ->
+            idem.execute(key, hash,
+                () -> confirmUC.confirm(new SkuId(req.skuId()), req.quantity())
+                                .replaceWith(Response.noContent().build()),
+                session));
+    }
+
+    @WithTransaction
+    public Uni<Response> release(String key, ReleaseRequest req) {
+        String hash = IdempotencyServiceReactive.hash("POST", "/v1/inventory/release", req);
+        return Panache.getSession().flatMap(session ->
+            idem.execute(key, hash,
+                () -> releaseUC.release(new SkuId(req.skuId()), req.quantity())
+                                .replaceWith(Response.noContent().build()),
+                session));
+    }
+
+    @WithTransaction
+    public Uni<Response> adjust(String key, AdjustRequest req) {
+        String hash = IdempotencyServiceReactive.hash("POST", "/v1/inventory/adjust", req);
+        return Panache.getSession().flatMap(session ->
+            idem.execute(key, hash,
+                () -> adjustUC.adjust(new SkuId(req.skuId()), req.delta())
+                                .map(agg -> Response.ok(toResponse(agg)).build()),
+                session));
+    }
+
+    private Response toCreatedResponse(StockAggregate agg) {
+        return Response.status(Response.Status.CREATED).entity(toResponse(agg)).build();
+    }
+
+    private StockResponse toResponse(StockAggregate agg) {
+        return new StockResponse(agg.skuId().value(), agg.onHand(), agg.reserved());
+    }
+
+    // DTOs
+    public record ReserveRequest(String skuId, long quantity) {}
+    public record ConfirmRequest(String skuId, long quantity) {}
+    public record ReleaseRequest(String skuId, long quantity) {}
+    public record AdjustRequest(String skuId, long delta) {}
+    public record StockResponse(String skuId, long onHand, long reserved) {}
+}
+

--- a/src/main/java/com/meli/infrastructure/rest/command/InventoryCommandResource.java
+++ b/src/main/java/com/meli/infrastructure/rest/command/InventoryCommandResource.java
@@ -1,97 +1,59 @@
 package com.meli.infrastructure.rest.command;
 
-import com.meli.application.service.IdempotencyServiceReactive;
-import com.meli.application.usecase.*;
-import com.meli.domain.model.SkuId;
-import com.meli.domain.model.StockAggregate;
+import com.meli.application.service.InventoryCommandService;
+import com.meli.application.service.InventoryCommandService.AdjustRequest;
+import com.meli.application.service.InventoryCommandService.ConfirmRequest;
+import com.meli.application.service.InventoryCommandService.ReleaseRequest;
+import com.meli.application.service.InventoryCommandService.ReserveRequest;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import io.quarkus.hibernate.reactive.panache.Panache;
-import io.quarkus.hibernate.reactive.panache.common.WithTransaction;
 
 @Path("/v1/inventory")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class InventoryCommandResource {
 
-  @Inject IdempotencyServiceReactive idem;
-  @Inject ReserveStockUC reserveUC;
-  @Inject ConfirmStockUC confirmUC;
-  @Inject ReleaseStockUC releaseUC;
-  @Inject AdjustStockUC  adjustUC;
+  private final InventoryCommandService service;
 
-  @POST @Path("/reserve")
-  @WithTransaction
+  @Inject
+  public InventoryCommandResource(InventoryCommandService service) {
+    this.service = service;
+  }
+
+  @POST
+  @Path("/reserve")
   public Uni<Response> reserve(@HeaderParam("Idempotency-Key") String key, ReserveRequest req) {
     ensureKey(key);
-    String hash = IdempotencyServiceReactive.hash("POST", "/v1/inventory/reserve", req);
-
-    return Panache.getSession().flatMap(session ->
-      idem.execute(key, hash,
-        () -> reserveUC.reserve(new SkuId(req.skuId()), req.quantity())
-                       .map(this::toCreatedResponse), // 201 + body
-        session));
+    return service.reserve(key, req);
   }
 
-  @POST @Path("/confirm")
-  @WithTransaction
+  @POST
+  @Path("/confirm")
   public Uni<Response> confirm(@HeaderParam("Idempotency-Key") String key, ConfirmRequest req) {
     ensureKey(key);
-    String hash = IdempotencyServiceReactive.hash("POST", "/v1/inventory/confirm", req);
-
-    return Panache.getSession().flatMap(session ->
-      idem.execute(key, hash,
-        () -> confirmUC.confirm(new SkuId(req.skuId()), req.quantity())
-                       .replaceWith(Response.noContent().build()), // 204
-        session));
+    return service.confirm(key, req);
   }
 
-  @POST @Path("/release")
-  @WithTransaction
+  @POST
+  @Path("/release")
   public Uni<Response> release(@HeaderParam("Idempotency-Key") String key, ReleaseRequest req) {
     ensureKey(key);
-    String hash = IdempotencyServiceReactive.hash("POST", "/v1/inventory/release", req);
-
-    return Panache.getSession().flatMap(session ->
-      idem.execute(key, hash,
-        () -> releaseUC.release(new SkuId(req.skuId()), req.quantity())
-                       .replaceWith(Response.noContent().build()),
-        session));
+    return service.release(key, req);
   }
 
-  @POST @Path("/adjust")
-  @WithTransaction
+  @POST
+  @Path("/adjust")
   public Uni<Response> adjust(@HeaderParam("Idempotency-Key") String key, AdjustRequest req) {
     ensureKey(key);
-    String hash = IdempotencyServiceReactive.hash("POST", "/v1/inventory/adjust", req);
-
-    return Panache.getSession().flatMap(session ->
-      idem.execute(key, hash,
-        () -> adjustUC.adjust(new SkuId(req.skuId()), req.delta())
-                      .map(agg -> Response.ok(toResponse(agg)).build()),
-        session));
+    return service.adjust(key, req);
   }
 
   private static void ensureKey(String key) {
-    if (key == null || key.isBlank())
+    if (key == null || key.isBlank()) {
       throw new WebApplicationException("Idempotency-Key required", 400);
+    }
   }
-
-  private Response toCreatedResponse(StockAggregate agg) {
-    return Response.status(Response.Status.CREATED).entity(toResponse(agg)).build();
-  }
-
-  private StockResponse toResponse(StockAggregate agg) {
-    return new StockResponse(agg.skuId().value(), agg.onHand(), agg.reserved());
-  }
-
-  // DTOs
-  public record ReserveRequest(String skuId, long quantity) {}
-  public record ConfirmRequest(String skuId, long quantity) {}
-  public record ReleaseRequest(String skuId, long quantity) {}
-  public record AdjustRequest(String skuId, long delta) {}
-  public record StockResponse(String skuId, long onHand, long reserved) {}
 }


### PR DESCRIPTION
## Summary
- move transaction and idempotency logic to new InventoryCommandService
- slim InventoryCommandResource to delegate to service

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a07b6880588333bb7f46733d0a9bbc