### PR TITLE
Refactor idempotency service to reduce complexity and add custom exception

### DIFF
--- a/src/main/java/com/meli/application/service/IdempotencyServiceException.java
+++ b/src/main/java/com/meli/application/service/IdempotencyServiceException.java
@@ -1,0 +1,14 @@
+package com.meli.application.service;
+
+/**
+ * Dedicated exception for errors produced inside IdempotencyServiceReactive.
+ */
+public class IdempotencyServiceException extends RuntimeException {
+  public IdempotencyServiceException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public IdempotencyServiceException(Throwable cause) {
+    super(cause);
+  }
+}


### PR DESCRIPTION
## Summary
- extract helper methods and constants for idempotency status
- introduce IdempotencyServiceException for json and hashing errors

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b3d49594833383786cf8e16314a7