### PR TITLE
feat: add audit logging

### DIFF
--- a/src/main/java/com/meli/application/usecase/AdjustStockUC.java
+++ b/src/main/java/com/meli/application/usecase/AdjustStockUC.java
@@ -5,6 +5,7 @@ import com.meli.domain.repository.StockRepository;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
 
 /**
  * Adjusts on hand stock by a delta value.
@@ -12,6 +13,7 @@ import jakarta.inject.Inject;
 @ApplicationScoped
 public class AdjustStockUC {
     private final StockRepository repository;
+    private static final Logger LOG = Logger.getLogger(AdjustStockUC.class);
 
     @Inject
     public AdjustStockUC(StockRepository repository) {
@@ -19,10 +21,14 @@ public class AdjustStockUC {
     }
 
     public Uni<StockAggregate> adjust(SkuId skuId, long delta) {
+        LOG.infov("Adjusting stock for {0} by {1}", skuId, delta);
         return repository.find(skuId)
                 .flatMap(stock -> {
                     var event = stock.adjust(delta);
                     return repository.save(stock, event);
-                });
+                })
+                .invoke(agg -> LOG.infov("Adjusted stock for {0}: onHand={1}, reserved={2}",
+                        skuId, agg.onHand(), agg.reserved()))
+                .onFailure().invoke(t -> LOG.errorf(t, "Error adjusting stock for %s", skuId));
     }
 }

--- a/src/main/java/com/meli/application/usecase/ReleaseStockUC.java
+++ b/src/main/java/com/meli/application/usecase/ReleaseStockUC.java
@@ -5,6 +5,7 @@ import com.meli.domain.repository.StockRepository;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
 
 /**
  * Releases reserved stock back to available pool.
@@ -12,6 +13,7 @@ import jakarta.inject.Inject;
 @ApplicationScoped
 public class ReleaseStockUC {
     private final StockRepository repository;
+    private static final Logger LOG = Logger.getLogger(ReleaseStockUC.class);
 
     @Inject
     public ReleaseStockUC(StockRepository repository) {
@@ -19,10 +21,14 @@ public class ReleaseStockUC {
     }
 
     public Uni<StockAggregate> release(SkuId skuId, long quantity) {
+        LOG.infov("Releasing stock for {0} qty {1}", skuId, quantity);
         return repository.find(skuId)
                 .flatMap(stock -> {
                     var event = stock.release(quantity);
                     return repository.save(stock, event);
-                });
+                })
+                .invoke(agg -> LOG.infov("Released stock for {0}: onHand={1}, reserved={2}",
+                        skuId, agg.onHand(), agg.reserved()))
+                .onFailure().invoke(t -> LOG.errorf(t, "Error releasing stock for %s", skuId));
     }
 }

--- a/src/main/java/com/meli/application/usecase/ReserveStockUC.java
+++ b/src/main/java/com/meli/application/usecase/ReserveStockUC.java
@@ -5,6 +5,7 @@ import com.meli.domain.repository.StockRepository;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
 
 /**
  * Reserves available stock for a SKU.
@@ -12,6 +13,7 @@ import jakarta.inject.Inject;
 @ApplicationScoped
 public class ReserveStockUC {
     private final StockRepository repository;
+    private static final Logger LOG = Logger.getLogger(ReserveStockUC.class);
 
     @Inject
     public ReserveStockUC(StockRepository repository) {
@@ -19,10 +21,14 @@ public class ReserveStockUC {
     }
 
     public Uni<StockAggregate> reserve(SkuId skuId, long quantity) {
+        LOG.infov("Reserving stock for {0} qty {1}", skuId, quantity);
         return repository.find(skuId)
                 .flatMap(stock -> {
                     var event = stock.reserve(quantity);
                     return repository.save(stock, event);
-                });
+                })
+                .invoke(agg -> LOG.infov("Reserved stock for {0}: onHand={1}, reserved={2}",
+                        skuId, agg.onHand(), agg.reserved()))
+                .onFailure().invoke(t -> LOG.errorf(t, "Error reserving stock for %s", skuId));
     }
 }

--- a/src/main/java/com/meli/infrastructure/logging/AuditExceptionMapper.java
+++ b/src/main/java/com/meli/infrastructure/logging/AuditExceptionMapper.java
@@ -1,0 +1,28 @@
+package com.meli.infrastructure.logging;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.jboss.logging.Logger;
+
+/**
+ * Logs unhandled exceptions before letting JAX-RS generate a response.
+ */
+@Provider
+public class AuditExceptionMapper implements ExceptionMapper<Throwable> {
+
+    private static final Logger LOG = Logger.getLogger(AuditExceptionMapper.class);
+
+    @Override
+    public Response toResponse(Throwable exception) {
+        if (exception instanceof WebApplicationException wae) {
+            LOG.errorf(wae, "HTTP %s error", wae.getResponse().getStatus());
+            return wae.getResponse();
+        }
+        LOG.error("Unhandled error", exception);
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity("Internal Server Error")
+                .build();
+    }
+}

--- a/src/main/java/com/meli/infrastructure/logging/AuditLogFilter.java
+++ b/src/main/java/com/meli/infrastructure/logging/AuditLogFilter.java
@@ -1,0 +1,32 @@
+package com.meli.infrastructure.logging;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+
+/**
+ * Simple request/response logging filter for audit purposes.
+ */
+@Provider
+public class AuditLogFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final Logger LOG = Logger.getLogger(AuditLogFilter.class);
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        LOG.infov("Incoming {0} {1}", requestContext.getMethod(), requestContext.getUriInfo().getRequestUri());
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        LOG.infov("Outgoing {0} {1} -> {2}",
+                requestContext.getMethod(),
+                requestContext.getUriInfo().getRequestUri(),
+                responseContext.getStatus());
+    }
+}


### PR DESCRIPTION
## Summary
- log all HTTP requests and responses
- capture uncaught errors with a global exception mapper
- add structured logging for each inventory command use case

## Testing
- `mvn -q test` *(fails: Unresolveable build extension... Could not transfer artifact due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b7413bcc8333834488c345ab9458