### PR TITLE
refactor: align project with hexagonal architecture

### DIFF
--- a/src/main/java/com/meli/application/port/in/InventoryCommandUseCase.java
+++ b/src/main/java/com/meli/application/port/in/InventoryCommandUseCase.java
@@ -1,0 +1,21 @@
+package com.meli.application.port.in;
+
+import io.smallrye.mutiny.Uni;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Input port for inventory command operations.
+ */
+public interface InventoryCommandUseCase {
+
+    Uni<Response> reserve(String key, ReserveRequest req);
+    Uni<Response> confirm(String key, ConfirmRequest req);
+    Uni<Response> release(String key, ReleaseRequest req);
+    Uni<Response> adjust(String key, AdjustRequest req);
+
+    record ReserveRequest(String skuId, long quantity) {}
+    record ConfirmRequest(String skuId, long quantity) {}
+    record ReleaseRequest(String skuId, long quantity) {}
+    record AdjustRequest(String skuId, long delta) {}
+    record StockResponse(String skuId, long onHand, long reserved) {}
+}

--- a/src/main/java/com/meli/application/port/out/StockRepository.java
+++ b/src/main/java/com/meli/application/port/out/StockRepository.java
@@ -1,4 +1,4 @@
-package com.meli.domain.repository;
+package com.meli.application.port.out;
 
 import com.meli.domain.model.*;
 import io.smallrye.mutiny.Uni;

--- a/src/main/java/com/meli/application/service/IdempotencyServiceReactive.java
+++ b/src/main/java/com/meli/application/service/IdempotencyServiceReactive.java
@@ -3,7 +3,7 @@ package com.meli.application.service;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.meli.infrastructure.repository.IdempotencyKeyEntity;
+import com.meli.infrastructure.adapter.out.persistence.IdempotencyKeyEntity;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.WebApplicationException;

--- a/src/main/java/com/meli/application/service/InventoryCommandService.java
+++ b/src/main/java/com/meli/application/service/InventoryCommandService.java
@@ -1,5 +1,11 @@
 package com.meli.application.service;
 
+import com.meli.application.port.in.InventoryCommandUseCase;
+import com.meli.application.port.in.InventoryCommandUseCase.AdjustRequest;
+import com.meli.application.port.in.InventoryCommandUseCase.ConfirmRequest;
+import com.meli.application.port.in.InventoryCommandUseCase.ReleaseRequest;
+import com.meli.application.port.in.InventoryCommandUseCase.ReserveRequest;
+import com.meli.application.port.in.InventoryCommandUseCase.StockResponse;
 import com.meli.application.usecase.*;
 import com.meli.domain.model.SkuId;
 import com.meli.domain.model.StockAggregate;
@@ -18,7 +24,7 @@ import org.jboss.logging.Logger;
  */
 @ApplicationScoped
 @RequiredArgsConstructor
-public class InventoryCommandService {
+public class InventoryCommandService implements InventoryCommandUseCase {
 
     private final IdempotencyServiceReactive idem;
     private final ReserveStockUC reserveUC;
@@ -27,6 +33,7 @@ public class InventoryCommandService {
     private final AdjustStockUC  adjustUC;
     private static final Logger LOG = Logger.getLogger(InventoryCommandService.class);
 
+    @Override
     @WithTransaction
     public Uni<Response> reserve(String key, ReserveRequest req) {
         LOG.infov("Reserve request key={0} sku={1} qty={2}", key, req.skuId(), req.quantity());
@@ -46,6 +53,7 @@ public class InventoryCommandService {
             .onFailure().invoke(t -> LOG.errorf(t, "Reserve failed key=%s", key));
     }
 
+    @Override
     @WithTransaction
     public Uni<Response> confirm(String key, ConfirmRequest req) {
         LOG.infov("Confirm request key={0} sku={1} qty={2}", key, req.skuId(), req.quantity());
@@ -59,6 +67,7 @@ public class InventoryCommandService {
             .onFailure().invoke(t -> LOG.errorf(t, "Confirm failed key=%s", key));
     }
 
+    @Override
     @WithTransaction
     public Uni<Response> release(String key, ReleaseRequest req) {
         LOG.infov("Release request key={0} sku={1} qty={2}", key, req.skuId(), req.quantity());
@@ -72,6 +81,7 @@ public class InventoryCommandService {
             .onFailure().invoke(t -> LOG.errorf(t, "Release failed key=%s", key));
     }
 
+    @Override
     @WithTransaction
     public Uni<Response> adjust(String key, AdjustRequest req) {
         LOG.infov("Adjust request key={0} sku={1} delta={2}", key, req.skuId(), req.delta());
@@ -93,11 +103,6 @@ public class InventoryCommandService {
         return new StockResponse(agg.skuId().value(), agg.onHand(), agg.reserved());
     }
 
-    // DTOs
-    public record ReserveRequest(String skuId, long quantity) {}
-    public record ConfirmRequest(String skuId, long quantity) {}
-    public record ReleaseRequest(String skuId, long quantity) {}
-    public record AdjustRequest(String skuId, long delta) {}
-    public record StockResponse(String skuId, long onHand, long reserved) {}
+    // DTOs moved to input port
 }
 

--- a/src/main/java/com/meli/application/usecase/AdjustStockUC.java
+++ b/src/main/java/com/meli/application/usecase/AdjustStockUC.java
@@ -1,7 +1,7 @@
 package com.meli.application.usecase;
 
 import com.meli.domain.model.*;
-import com.meli.domain.repository.StockRepository;
+import com.meli.application.port.out.StockRepository;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/src/main/java/com/meli/application/usecase/ConfirmStockUC.java
+++ b/src/main/java/com/meli/application/usecase/ConfirmStockUC.java
@@ -1,7 +1,7 @@
 package com.meli.application.usecase;
 
 import com.meli.domain.model.*;
-import com.meli.domain.repository.StockRepository;
+import com.meli.application.port.out.StockRepository;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/src/main/java/com/meli/application/usecase/ReleaseStockUC.java
+++ b/src/main/java/com/meli/application/usecase/ReleaseStockUC.java
@@ -1,7 +1,7 @@
 package com.meli.application.usecase;
 
 import com.meli.domain.model.*;
-import com.meli.domain.repository.StockRepository;
+import com.meli.application.port.out.StockRepository;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/src/main/java/com/meli/application/usecase/ReserveStockUC.java
+++ b/src/main/java/com/meli/application/usecase/ReserveStockUC.java
@@ -1,7 +1,7 @@
 package com.meli.application.usecase;
 
 import com.meli.domain.model.*;
-import com.meli.domain.repository.StockRepository;
+import com.meli.application.port.out.StockRepository;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/src/main/java/com/meli/infrastructure/adapter/in/logging/AuditExceptionMapper.java
+++ b/src/main/java/com/meli/infrastructure/adapter/in/logging/AuditExceptionMapper.java
@@ -1,4 +1,4 @@
-package com.meli.infrastructure.logging;
+package com.meli.infrastructure.adapter.in.logging;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;

--- a/src/main/java/com/meli/infrastructure/adapter/in/logging/AuditLogFilter.java
+++ b/src/main/java/com/meli/infrastructure/adapter/in/logging/AuditLogFilter.java
@@ -1,4 +1,4 @@
-package com.meli.infrastructure.logging;
+package com.meli.infrastructure.adapter.in.logging;
 
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;

--- a/src/main/java/com/meli/infrastructure/adapter/in/rest/InventoryCommandResource.java
+++ b/src/main/java/com/meli/infrastructure/adapter/in/rest/InventoryCommandResource.java
@@ -1,10 +1,10 @@
-package com.meli.infrastructure.rest.command;
+package com.meli.infrastructure.adapter.in.rest;
 
-import com.meli.application.service.InventoryCommandService;
-import com.meli.application.service.InventoryCommandService.AdjustRequest;
-import com.meli.application.service.InventoryCommandService.ConfirmRequest;
-import com.meli.application.service.InventoryCommandService.ReleaseRequest;
-import com.meli.application.service.InventoryCommandService.ReserveRequest;
+import com.meli.application.port.in.InventoryCommandUseCase;
+import com.meli.application.port.in.InventoryCommandUseCase.AdjustRequest;
+import com.meli.application.port.in.InventoryCommandUseCase.ConfirmRequest;
+import com.meli.application.port.in.InventoryCommandUseCase.ReleaseRequest;
+import com.meli.application.port.in.InventoryCommandUseCase.ReserveRequest;
 import io.smallrye.mutiny.Uni;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class InventoryCommandResource {
 
-  private final InventoryCommandService service;
+  private final InventoryCommandUseCase service;
 
   @POST
   @Path("/reserve")

--- a/src/main/java/com/meli/infrastructure/adapter/out/persistence/IdempotencyCleanupScheduler.java
+++ b/src/main/java/com/meli/infrastructure/adapter/out/persistence/IdempotencyCleanupScheduler.java
@@ -1,4 +1,4 @@
-package com.meli.infrastructure.repository;
+package com.meli.infrastructure.adapter.out.persistence;
 
 import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;

--- a/src/main/java/com/meli/infrastructure/adapter/out/persistence/IdempotencyKeyEntity.java
+++ b/src/main/java/com/meli/infrastructure/adapter/out/persistence/IdempotencyKeyEntity.java
@@ -1,4 +1,4 @@
-package com.meli.infrastructure.repository;
+package com.meli.infrastructure.adapter.out.persistence;
 
 import io.quarkus.hibernate.reactive.panache.PanacheEntityBase;
 import jakarta.persistence.*;

--- a/src/main/java/com/meli/infrastructure/adapter/out/persistence/OutboxEntity.java
+++ b/src/main/java/com/meli/infrastructure/adapter/out/persistence/OutboxEntity.java
@@ -1,4 +1,4 @@
-package com.meli.infrastructure.repository;
+package com.meli.infrastructure.adapter.out.persistence;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;

--- a/src/main/java/com/meli/infrastructure/adapter/out/persistence/OutboxPublisher.java
+++ b/src/main/java/com/meli/infrastructure/adapter/out/persistence/OutboxPublisher.java
@@ -1,4 +1,4 @@
-package com.meli.infrastructure.repository;
+package com.meli.infrastructure.adapter.out.persistence;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/src/main/java/com/meli/infrastructure/adapter/out/persistence/ReactiveStockRepository.java
+++ b/src/main/java/com/meli/infrastructure/adapter/out/persistence/ReactiveStockRepository.java
@@ -1,8 +1,8 @@
-package com.meli.infrastructure.repository;
+package com.meli.infrastructure.adapter.out.persistence;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meli.domain.model.*;
-import com.meli.domain.repository.StockRepository;
+import com.meli.application.port.out.StockRepository;
 import io.quarkus.hibernate.reactive.panache.Panache;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;

--- a/src/main/java/com/meli/infrastructure/adapter/out/persistence/StockEntity.java
+++ b/src/main/java/com/meli/infrastructure/adapter/out/persistence/StockEntity.java
@@ -1,4 +1,4 @@
-package com.meli.infrastructure.repository;
+package com.meli.infrastructure.adapter.out.persistence;
 
 import com.meli.domain.model.*;
 import jakarta.persistence.*;

--- a/src/test/java/com/meli/ReserveStockUCTest.java
+++ b/src/test/java/com/meli/ReserveStockUCTest.java
@@ -2,7 +2,7 @@ package com.meli;
 
 import com.meli.application.usecase.ReserveStockUC;
 import com.meli.domain.model.*;
-import com.meli.domain.repository.StockRepository;
+import com.meli.application.port.out.StockRepository;
 import io.smallrye.mutiny.Uni;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary
- extract inventory command port and request/response records
- move repository port and infrastructure adapters to hexagonal layout
- update REST resource to depend on input port

## Testing
- `mvn -q test` *(fails: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.8.4 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b9bc49dc83338a6cdf1ec36c3a18